### PR TITLE
Dedupe disposal warnings and group warning records by value

### DIFF
--- a/schema/output.json
+++ b/schema/output.json
@@ -73,13 +73,6 @@
         },
         "rule": {
           "type": "string"
-        },
-        "warnings": {
-          "description": "Warnings for this disposal (e.g., \"Unclassified\", \"NoCostBasis\", \"InsufficientPool\")",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         }
       },
       "required": [
@@ -87,8 +80,7 @@
         "cost_gbp",
         "gain_gbp",
         "rule",
-        "matching_components",
-        "warnings"
+        "matching_components"
       ]
     },
     "EventRow": {

--- a/src/cmd/report/mod.rs
+++ b/src/cmd/report/mod.rs
@@ -411,20 +411,27 @@ pub(super) fn build_report_data(
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    let warnings: Vec<WarningRecord> = event_rows
-        .iter()
-        .flat_map(|event| {
-            event.warnings.iter().map(move |warning| {
-                let source_transaction_ids = vec![event.source_transaction_id.clone()];
-                let related_event_ids = vec![event.id];
-
-                WarningRecord {
-                    warning: warning.clone(),
-                    source_transaction_ids,
-                    related_event_ids,
-                }
-            })
-        })
+    let mut warning_map: HashMap<Warning, (Vec<String>, Vec<usize>)> = HashMap::new();
+    for event in &event_rows {
+        for warning in &event.warnings {
+            let entry = warning_map.entry(warning.clone()).or_default();
+            if !entry.0.contains(&event.source_transaction_id) {
+                entry.0.push(event.source_transaction_id.clone());
+            }
+            if !entry.1.contains(&event.id) {
+                entry.1.push(event.id);
+            }
+        }
+    }
+    let warnings: Vec<WarningRecord> = warning_map
+        .into_iter()
+        .map(
+            |(warning, (source_transaction_ids, related_event_ids))| WarningRecord {
+                warning,
+                source_transaction_ids,
+                related_event_ids,
+            },
+        )
         .collect();
 
     // Build asset -> asset_class mapping from events

--- a/src/cmd/report/mod.rs
+++ b/src/cmd/report/mod.rs
@@ -170,8 +170,6 @@ pub struct CgtDetails {
     pub gain_gbp: String,
     pub rule: String,
     pub matching_components: Vec<MatchingComponentRow>,
-    /// Warnings for this disposal (e.g., "Unclassified", "NoCostBasis", "InsufficientPool")
-    pub warnings: Vec<String>,
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -363,17 +361,12 @@ pub(super) fn build_report_data(
                         })
                         .collect();
 
-                    // Convert warnings to display strings
-                    let warnings: Vec<String> =
-                        d.warnings.iter().map(format_event_warning).collect();
-
                     CgtDetails {
                         proceeds_gbp: gbp_2dp(d.proceeds_gbp),
                         cost_gbp: gbp_2dp(d.allowable_cost_gbp),
                         gain_gbp: gbp_2dp(d.gain_gbp),
                         rule,
                         matching_components,
-                        warnings,
                     }
                 })
             } else {
@@ -687,22 +680,6 @@ fn format_matching_rule(rule: &MatchingRule) -> String {
         MatchingRule::Pool => "Pool",
     }
     .to_string()
-}
-
-fn format_event_warning(warning: &Warning) -> String {
-    match warning {
-        Warning::UnclassifiedEvent => "Unclassified".to_string(),
-        Warning::InsufficientCostBasis {
-            available,
-            required,
-        } => {
-            if available.is_zero() {
-                "NoCostBasis".to_string()
-            } else {
-                format!("InsufficientCostBasis({}/{})", available, required)
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/cmd/report/mod.rs
+++ b/src/cmd/report/mod.rs
@@ -411,29 +411,7 @@ pub(super) fn build_report_data(
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    let mut warning_map: HashMap<Warning, (Vec<String>, Vec<usize>)> = HashMap::new();
-    for event in &event_rows {
-        for warning in &event.warnings {
-            let entry = warning_map.entry(warning.clone()).or_default();
-            if !entry.0.contains(&event.source_transaction_id) {
-                entry.0.push(event.source_transaction_id.clone());
-            }
-            if !entry.1.contains(&event.id) {
-                entry.1.push(event.id);
-            }
-        }
-    }
-    let mut warnings: Vec<WarningRecord> = warning_map
-        .into_iter()
-        .map(
-            |(warning, (source_transaction_ids, related_event_ids))| WarningRecord {
-                warning,
-                source_transaction_ids,
-                related_event_ids,
-            },
-        )
-        .collect();
-    warnings.sort_by_key(|w| w.related_event_ids.first().copied());
+    let warnings = group_warnings(&event_rows);
 
     // Build asset -> asset_class mapping from events
     let asset_class_map: HashMap<String, AssetClass> = filtered_events
@@ -679,6 +657,39 @@ fn format_asset_class(ac: &AssetClass) -> String {
         AssetClass::Fiat => "Fiat",
     }
     .to_string()
+}
+
+/// Group event warnings into one record per distinct warning value, ordered
+/// by first affected event with the warning value as tie-breaker (one event
+/// can carry both an Unclassified and an InsufficientCostBasis warning).
+/// Transaction and event ids are unique per warning value upstream, so the
+/// accumulated id lists need no dedup.
+fn group_warnings(event_rows: &[EventRow]) -> Vec<WarningRecord> {
+    let mut groups: HashMap<&Warning, (Vec<String>, Vec<usize>)> = HashMap::new();
+    for event in event_rows {
+        for warning in &event.warnings {
+            let entry = groups.entry(warning).or_default();
+            entry.0.push(event.source_transaction_id.clone());
+            entry.1.push(event.id);
+        }
+    }
+    let mut warnings: Vec<WarningRecord> = groups
+        .into_iter()
+        .map(
+            |(warning, (source_transaction_ids, related_event_ids))| WarningRecord {
+                warning: warning.clone(),
+                source_transaction_ids,
+                related_event_ids,
+            },
+        )
+        .collect();
+    warnings.sort_by_key(|w| {
+        (
+            w.related_event_ids.first().copied(),
+            format!("{:?}", w.warning),
+        )
+    });
+    warnings
 }
 
 fn format_matching_rule(rule: &MatchingRule) -> String {

--- a/src/cmd/report/mod.rs
+++ b/src/cmd/report/mod.rs
@@ -423,7 +423,7 @@ pub(super) fn build_report_data(
             }
         }
     }
-    let warnings: Vec<WarningRecord> = warning_map
+    let mut warnings: Vec<WarningRecord> = warning_map
         .into_iter()
         .map(
             |(warning, (source_transaction_ids, related_event_ids))| WarningRecord {
@@ -433,6 +433,7 @@ pub(super) fn build_report_data(
             },
         )
         .collect();
+    warnings.sort_by_key(|w| w.related_event_ids.first().copied());
 
     // Build asset -> asset_class mapping from events
     let asset_class_map: HashMap<String, AssetClass> = filtered_events

--- a/src/cmd/report/tests.rs
+++ b/src/cmd/report/tests.rs
@@ -136,6 +136,55 @@ fn warning_records_link_source_transaction_and_event_ids() {
 }
 
 #[test]
+fn warning_records_grouped_by_value_and_ordered_by_first_event() {
+    let events = vec![
+        TaxableEvent {
+            id: 1,
+            source_transaction_id: "tx-1".to_string(),
+            ..disp("2024-06-01", "BTC", dec!(1), dec!(25000))
+        },
+        TaxableEvent {
+            id: 2,
+            source_transaction_id: "tx-2".to_string(),
+            ..acq("2024-05-01", "ETH", dec!(2), dec!(2000))
+        },
+        TaxableEvent {
+            id: 3,
+            source_transaction_id: "tx-3".to_string(),
+            tag: Tag::Unclassified,
+            ..disp("2024-06-02", "ETH", dec!(1), dec!(1500))
+        },
+        TaxableEvent {
+            id: 4,
+            source_transaction_id: "tx-4".to_string(),
+            tag: Tag::Unclassified,
+            ..disp("2024-06-03", "ETH", dec!(1), dec!(1500))
+        },
+    ];
+
+    let cgt_report = calculate_cgt(events.clone()).unwrap();
+    let data = build_report_data(&[], &events, &cgt_report, &no_filter()).unwrap();
+
+    assert_eq!(
+        data.warnings.len(),
+        2,
+        "equal warnings should share a record"
+    );
+    assert!(matches!(
+        data.warnings[0].warning,
+        Warning::InsufficientCostBasis { .. }
+    ));
+    assert!(matches!(
+        data.warnings[1].warning,
+        Warning::UnclassifiedEvent
+    ));
+
+    let unclassified = &data.warnings[1];
+    assert_eq!(unclassified.source_transaction_ids, vec!["tx-3", "tx-4"]);
+    assert_eq!(unclassified.related_event_ids, vec![3, 4]);
+}
+
+#[test]
 fn summary_includes_dividend_and_interest_totals() {
     let events = vec![
         TaxableEvent {

--- a/src/cmd/report/tests.rs
+++ b/src/cmd/report/tests.rs
@@ -185,6 +185,63 @@ fn warning_records_grouped_by_value_and_ordered_by_first_event() {
 }
 
 #[test]
+fn warning_records_distinct_insufficient_cost_basis_values_stay_separate() {
+    let events = vec![
+        TaxableEvent {
+            id: 1,
+            source_transaction_id: "tx-1".to_string(),
+            ..disp("2024-06-01", "BTC", dec!(1), dec!(25000))
+        },
+        TaxableEvent {
+            id: 2,
+            source_transaction_id: "tx-2".to_string(),
+            ..disp("2024-07-01", "BTC", dec!(2), dec!(50000))
+        },
+    ];
+
+    let cgt_report = calculate_cgt(events.clone()).unwrap();
+    let data = build_report_data(&[], &events, &cgt_report, &no_filter()).unwrap();
+
+    assert_eq!(
+        data.warnings.len(),
+        2,
+        "warnings with different field values must not merge"
+    );
+    assert!(data
+        .warnings
+        .iter()
+        .all(|w| matches!(w.warning, Warning::InsufficientCostBasis { .. })));
+    assert_eq!(data.warnings[0].related_event_ids, vec![1]);
+    assert_eq!(data.warnings[1].related_event_ids, vec![2]);
+}
+
+#[test]
+fn warning_records_same_first_event_tie_breaks_deterministically() {
+    // One unclassified disposal with no pool carries both warning values, so
+    // both grouped records share first related event id 1 and ordering falls
+    // to the warning-value tie-breaker.
+    let events = vec![TaxableEvent {
+        id: 1,
+        source_transaction_id: "tx-1".to_string(),
+        tag: Tag::Unclassified,
+        ..disp("2024-06-01", "BTC", dec!(1), dec!(25000))
+    }];
+
+    let cgt_report = calculate_cgt(events.clone()).unwrap();
+    let data = build_report_data(&[], &events, &cgt_report, &no_filter()).unwrap();
+
+    assert_eq!(data.warnings.len(), 2);
+    assert!(matches!(
+        data.warnings[0].warning,
+        Warning::InsufficientCostBasis { .. }
+    ));
+    assert!(matches!(
+        data.warnings[1].warning,
+        Warning::UnclassifiedEvent
+    ));
+}
+
+#[test]
 fn summary_includes_dividend_and_interest_totals() {
     let events = vec![
         TaxableEvent {

--- a/src/core/warnings.rs
+++ b/src/core/warnings.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Domain warning types emitted during conversion/calculation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type")]
 pub enum Warning {
     /// Event was unclassified and may need manual review.

--- a/tests/data/insufficient_cost_basis.json
+++ b/tests/data/insufficient_cost_basis.json
@@ -1,0 +1,16 @@
+{
+  "assets": [
+    { "symbol": "BTC", "asset_class": "Crypto" }
+  ],
+  "transactions": [
+    {
+      "id": "tx-001",
+      "datetime": "2024-06-15T09:00:00+00:00",
+      "account": "kraken",
+      "description": "Sell without cost basis",
+      "type": "Trade",
+      "sold": { "asset": "BTC", "quantity": 1 },
+      "bought": { "asset": "GBP", "quantity": 25000 }
+    }
+  ]
+}

--- a/tests/detailed_report.rs
+++ b/tests/detailed_report.rs
@@ -531,3 +531,42 @@ fn pools_non_daily_date_filter_behavior_is_explicit() {
         "expected empty snapshots for future range"
     );
 }
+
+/// Defense-in-depth: the grouped warnings JSON shape, exercised end-to-end
+/// through the compiled binary. Disposal-level cgt objects must not carry a
+/// warnings key (removed in favour of event-level and top-level warnings).
+#[test]
+fn report_json_warnings_grouped_with_no_cgt_warnings_key() {
+    let output = run_taxc(&[
+        "report",
+        "tests/data/insufficient_cost_basis.json",
+        "--json",
+    ]);
+
+    assert!(output.status.success(), "Command failed: {:?}", output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("Invalid JSON output");
+
+    let warnings = json["warnings"].as_array().expect("Missing warnings array");
+    assert_eq!(warnings.len(), 1, "expected one grouped warning record");
+    assert_eq!(
+        warnings[0]["warning"]["type"], "InsufficientCostBasis",
+        "warning must be a type-tagged object"
+    );
+    assert_eq!(warnings[0]["related_event_ids"][0], 1);
+    assert_eq!(warnings[0]["source_transaction_ids"][0], "tx-001");
+
+    let events = json["events"].as_array().expect("Missing events array");
+    let disposal = events
+        .iter()
+        .find(|e| e["event_type"] == "Disposal")
+        .expect("expected a disposal event");
+    assert!(
+        disposal["cgt"].get("warnings").is_none(),
+        "cgt objects must not contain a warnings key"
+    );
+    assert!(
+        disposal["warnings"].is_array(),
+        "event-level structured warnings must be present"
+    );
+}


### PR DESCRIPTION
Salvages the two follow-up commits from `feat/unified-warnings-report` that were written after PR #9 was squash-merged but never pushed, plus a determinism fix they needed.

Disposal warnings are no longer serialized twice in the JSON report: the stringified `CgtDetails.warnings` field is gone, leaving the structured event-level warnings as the single source (the HTML report already only read those). The top-level warnings list now groups identical warnings into one record listing every affected transaction and event, instead of emitting one record per event-warning pair.

The original grouping commit collected records into a `HashMap`, which would have made the order of warning records in report output random on every run — a new test failed 8 of 20 runs against it. Records are now sorted by first related event id, and `schema/output.json` is regenerated for the field removal. The third unpushed commit (placeholder event IDs) was dropped as master already implements it via `UNASSIGNED_ID`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
