### PR TITLE
Remove proc-macro-error2 from dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,9 +1113,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "papergrid"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "bytecount",
  "fnv",
@@ -1201,28 +1201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -1743,26 +1721,12 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4", features = ["derive"] }
 anyhow = "1.0"
 rust_decimal = { version = "1.40", features = ["serde"] }
 rust_decimal_macros = "1.40"
-tabled = "0.20"
+tabled = { version = "0.21", default-features = false, features = ["std"] }
 serde_json = "1.0"
 opener = "0.8"
 thiserror = "2.0"

--- a/src/cmd/pools.rs
+++ b/src/cmd/pools.rs
@@ -11,8 +11,8 @@ use rust_decimal::Decimal;
 use serde::Serialize;
 use std::path::PathBuf;
 use tabled::{
+    builder::Builder,
     settings::{object::Rows, Alignment, Modify, Style},
-    Table, Tabled,
 };
 
 #[derive(Args, Debug)]
@@ -105,24 +105,25 @@ impl PoolsCommand {
 
         for snapshot in snapshots {
             println!("Tax Year {}", snapshot.tax_year);
-            let rows: Vec<YearEndRow> = snapshot
-                .pools
-                .iter()
-                .map(|p| YearEndRow {
-                    asset: p.asset.clone(),
-                    quantity: format_quantity(p.quantity),
-                    cost_gbp: format_gbp(p.cost_gbp),
-                    cost_basis: format_gbp(cost_basis(p.quantity, p.cost_gbp)),
-                })
-                .collect();
-
-            if rows.is_empty() {
+            if snapshot.pools.is_empty() {
                 println!("  (no pools)");
                 println!();
                 continue;
             }
 
-            let table = Table::new(rows)
+            let mut builder = Builder::with_capacity(snapshot.pools.len() + 1, 4);
+            builder.push_record(["Asset", "Quantity", "Cost (GBP)", "Cost Basis"]);
+            for pool in &snapshot.pools {
+                builder.push_record([
+                    pool.asset.clone(),
+                    format_quantity(pool.quantity),
+                    format_gbp(pool.cost_gbp),
+                    format_gbp(cost_basis(pool.quantity, pool.cost_gbp)),
+                ]);
+            }
+
+            let table = builder
+                .build()
                 .with(Style::rounded())
                 .with(Modify::new(Rows::new(1..)).with(Alignment::right()))
                 .to_string();
@@ -137,23 +138,32 @@ impl PoolsCommand {
             return;
         }
 
-        let rows: Vec<DailyRow> = entries
-            .iter()
-            .map(|e| DailyRow {
-                date: e.date.format("%Y-%m-%d").to_string(),
-                asset: e.asset.clone(),
-                event: display_event_type(e.event_type, e.tag).to_string(),
-                quantity: format_quantity(e.quantity),
-                cost_gbp: format_gbp(e.cost_gbp),
-                cost_basis: format_gbp(cost_basis(e.quantity, e.cost_gbp)),
-            })
-            .collect();
-
         println!();
         println!("POOL HISTORY");
         println!();
 
-        let table = Table::new(rows)
+        let mut builder = Builder::with_capacity(entries.len() + 1, 6);
+        builder.push_record([
+            "Date",
+            "Asset",
+            "Event",
+            "Quantity",
+            "Cost (GBP)",
+            "Cost Basis",
+        ]);
+        for entry in entries {
+            builder.push_record([
+                entry.date.format("%Y-%m-%d").to_string(),
+                entry.asset.clone(),
+                display_event_type(entry.event_type, entry.tag).to_string(),
+                format_quantity(entry.quantity),
+                format_gbp(entry.cost_gbp),
+                format_gbp(cost_basis(entry.quantity, entry.cost_gbp)),
+            ]);
+        }
+
+        let table = builder
+            .build()
             .with(Style::rounded())
             .with(Modify::new(Rows::new(1..)).with(Alignment::right()))
             .to_string();
@@ -177,34 +187,6 @@ impl PoolsCommand {
         println!("{}", serde_json::to_string_pretty(&output)?);
         Ok(())
     }
-}
-
-#[derive(Debug, Clone, Tabled)]
-struct YearEndRow {
-    #[tabled(rename = "Asset")]
-    asset: String,
-    #[tabled(rename = "Quantity")]
-    quantity: String,
-    #[tabled(rename = "Cost (GBP)")]
-    cost_gbp: String,
-    #[tabled(rename = "Cost Basis")]
-    cost_basis: String,
-}
-
-#[derive(Debug, Clone, Tabled)]
-struct DailyRow {
-    #[tabled(rename = "Date")]
-    date: String,
-    #[tabled(rename = "Asset")]
-    asset: String,
-    #[tabled(rename = "Event")]
-    event: String,
-    #[tabled(rename = "Quantity")]
-    quantity: String,
-    #[tabled(rename = "Cost (GBP)")]
-    cost_gbp: String,
-    #[tabled(rename = "Cost Basis")]
-    cost_basis: String,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary
- Update tabled to 0.21 with default features disabled so tabled_derive is not enabled
- Replace Tabled derives in the pools command with the tabled runtime builder API
- Remove proc-macro-error2, proc-macro-error-attr2, and tabled_derive from Cargo.lock

## Test Plan
- cargo test
- cargo clippy
- cargo tree -i proc-macro-error2

Closes #14